### PR TITLE
Update two tests for I64<->BigInt conversion

### DIFF
--- a/test/js-api/bad-imports.js
+++ b/test/js-api/bad-imports.js
@@ -45,8 +45,8 @@ function test_bad_imports(t) {
       value);
   }
 
-  t(`Importing an i64 global`,
-    new WebAssembly.LinkError(),
+  t(`Importing an i64 global with an incorrectly-typed value`,
+    new TypeError(),
     builder => {
       builder.addImportedGlobal("module", "global", kWasmI64);
     },

--- a/test/js-api/global/constructor.any.js
+++ b/test/js-api/global/constructor.any.js
@@ -90,8 +90,9 @@ test(() => {
 test(() => {
   const argument = { "value": "i64" };
   const global = new WebAssembly.Global(argument);
-  assert_throws(new TypeError(), () => global.value);
-  assert_throws(new TypeError(), () => global.valueOf());
+
+  assert_equals(global.value, 0n, "initial value using ToJSValue");
+  assert_equals(global.valueOf(), 0n, "initial value using ToJSValue");
 }, "i64 with default");
 
 for (const type of ["i32", "f32", "f64"]) {


### PR DESCRIPTION
Updates some additional tests (`instance/constructor-bad-imports`, `constructor/instantiate-bad-imports` and `global/constructor.any`). Caught the failures on WIP Spidermonkey I64/BigInt branch.