### PR TITLE
Fix f32 global object test case in bad-imports.js

### DIFF
--- a/test/js-api/bad-imports.js
+++ b/test/js-api/bad-imports.js
@@ -78,12 +78,12 @@ function test_bad_imports(t) {
     [WebAssembly.Global, "WebAssembly.Global"],
     [WebAssembly.Global.prototype, "WebAssembly.Global.prototype"],
     [Object.create(WebAssembly.Global.prototype), "Object.create(WebAssembly.Global.prototype)"],
-    [new WebAssembly.Global({value: "f32"}), "WebAssembly.Global object (wrong value type)"],
   ];
 
   for (const type of ["i32", "i64", "f32", "f64"]) {
     const extendedNonGlobals = nonGlobals.concat([
-      type === "i64" ? [0, "Number"] : [0n, "BigInt"]
+      type === "i64" ? [0, "Number"] : [0n, "BigInt"],
+      [new WebAssembly.Global({value: type === "f32" ? "f64" : "f32"}), "WebAssembly.Global object (wrong value type)"],
     ]);
     for (const [value, name = format_value(value)] of extendedNonGlobals) {
       t(`Importing an ${type} global with an incorrectly-typed value: ${name}`,


### PR DESCRIPTION
There is a test case in the current bigint/i64 spec tests that tests for a wrong value type, but it seems to spuriously fail in the `f32` case because the value type is ok in that case.

I've adjusted the test case so that it will supply a wrong `"f32"` value in the non-f32 cases, and `"f64"` for `f32`. Wasn't 100% sure if this was the originally intended test, but it was my guess.